### PR TITLE
Update to ansible-avd 3.5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,14 +64,14 @@ ENTRYPOINT [ "/bin/entrypoint.sh" ]
 COPY ./gitconfig /home/avd/gitconfig-avd-base-template
 
 # change this for every release
-ENV _AVD_VERSION="3.4.0"
+ENV _AVD_VERSION="3.5.0"
 ENV _CVP_VERSION="3.3.1"
 
 # labels to be changed for every release
 LABEL maintainer="Arista Ansible Team <ansible@arista.com>"
-LABEL com.example.version="avd3.4.0_cvp3.3.1_debian"
+LABEL com.example.version="avd3.5.0_cvp3.3.1_debian"
 LABEL vendor1="Arista"
-LABEL com.example.release-date="2022-04-10"
+LABEL com.example.release-date="2022-06-13"
 LABEL com.example.version.is-production="False"
 
 # install ansible.cvp, ansible.avd collections and their requirements


### PR DESCRIPTION
Updating the all-in-one container to use the latest release of ansible-avd (v3.5.0)