### PR TITLE
Add multi-platform support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,16 @@ build_and_push: ## Build docker image
 	  docker push avdteam/avd-all-in-one:$(BRANCH);\
     fi
 
+# Note that there is currently no way to locally load a multi-platform image
+# See https://github.com/docker/buildx/issues/59
+.PHONY: buildx_and_push
+buildx_and_push: ## Build multi-platform docker image
+	if [ $(BRANCH) = 'master' ]; then \
+	  docker buildx build --push --platform linux/amd64,linux/arm64 --rm --pull -t $(DOCKER_NAME):latest -f $(CURRENT_DIR)/Dockerfile .;\
+	else \
+	  docker buildx build --push  --platform linux/amd64,linux/arm64 --rm --pull -t $(DOCKER_NAME):$(BRANCH) -f $(CURRENT_DIR)/Dockerfile .;\
+    fi
+
 .PHONY: run
 run: ## run docker image
 	if [ $(BRANCH) = 'master' ]; then \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For details, check [avd-base container documentation](https://github.com/arista-
 
 ### Before avd3.3.3_cvp3.3.1_debian
 
-`ansible.cfg` in AVD inventory repository must have following settings for avd-all-in-one container to work correctly: `collections_paths = /home/avd/ansible-cvp:/home/avd/ansible-avd:/home/avd/.ansible/collections/ansible_collections`  
+`ansible.cfg` in AVD inventory repository must have following settings for avd-all-in-one container to work correctly: `collections_paths = /home/avd/ansible-cvp:/home/avd/ansible-avd:/home/avd/.ansible/collections/ansible_collections`
 If you have to override that for development purposes, mount ansible-avd or ansible-cvp repositories from your machine to `/home/avd/ansible-cvp` or `/home/avd/ansible-avd` manually or using similar settings in `vscode.json`:
 
 ```json
@@ -59,7 +59,7 @@ Use following `devcontainer.json` to start:
     "image": "avdteam/avd-all-in-one:latest",
 
     // Set *default* container specific settings.json values on container create.
-    "settings": { 
+    "settings": {
         "python.testing.pytestPath": "/root/.local/bin/pytest",
 
         "python.pythonPath": "/usr/local/bin/python",
@@ -126,6 +126,18 @@ The below example is for running the pod on one specific node (set by the `nodeN
 
 > Note that the pod can be also deployed on any node by removing the `nodeName` field from the spec, however that would also require
 > pulling the image onto all nodes and synchronozing the project files between all nodes.
+
+## Multi-Platform Builds
+
+It is possible to build avd-all-in-one using Docker desktop's buildx framework for multiple architectures (e.g. x86 and arm64).  This requires setup of a 'docker-container' builder using:
+
+```
+docker buildx create --name mybuilder --driver docker-container --bootstrap --use
+```
+
+For more information see the [Docker documentation](https://docs.docker.com/build/building/multi-platform/).
+
+Also note that it is not currently possible to build a multi-platform container and export to the local image store.  See (https://github.com/docker/buildx/issues/59) for more information.
 
 ## Known Caveats
 


### PR DESCRIPTION
Added support for multi-platform builds using buildx - see https://docs.docker.com/build/building/multi-platform/ for more info.  There's a test multi-platform build built on a native arm64 machine at jonstill440/avd-all-in-one:latest.  I've added an extra target to retain the existing single-platform build functionality.