### PR TITLE
Bump: AVD version to 3.8.4

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -2,9 +2,9 @@
 name: build avd-all-in-one container
 
 env:
-  _AVD_VERSION: "3.8.3"
+  _AVD_VERSION: "3.8.4"
   _CVP_VERSION: "3.6.0"
-  _RELEASE_DATE: "2023-03-11"
+  _RELEASE_DATE: "2023-03-27"
 
 on:
   push:

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -77,5 +77,5 @@ jobs:
         with:
           package-name: avd-all-in-one-container/avd-all-in-one
           package-type: container
-          min-versions-to-keep: 15
+          min-versions-to-keep: 60
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -42,7 +42,7 @@ jobs:
           tags: |
             type=raw,value=latest
             type=raw,value=avd${{ env._AVD_VERSION }}_cvp${{ env._CVP_VERSION }}
-      # build the image
+      # only build the image in forked branches
       - name: Build without pushing
         uses: docker/build-push-action@v4
         if: github.repository_owner != 'arista-netdevops-community'
@@ -73,6 +73,7 @@ jobs:
       # delete old images
       - name: Delete old containers
         uses: actions/delete-package-versions@v4
+        if: github.repository_owner == 'arista-netdevops-community'
         with:
           package-name: avd-all-in-one-container/avd-all-in-one
           package-type: container

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -44,10 +44,10 @@ jobs:
             type=raw,value=avd${{ env._AVD_VERSION }}_cvp${{ env._CVP_VERSION }}
       # build the image
       - name: Build without pushing
-        uses: docker/build-action@v4
+        uses: docker/build-push-action@v4
         if: github.repository_owner != 'arista-netdevops-community'
         with:
-          push: true
+          push: false
           build-args: |
             _AVD_VERSION=${{ env._AVD_VERSION }}
             _CVP_VERSION=${{ env._CVP_VERSION }}

--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -42,9 +42,24 @@ jobs:
           tags: |
             type=raw,value=latest
             type=raw,value=avd${{ env._AVD_VERSION }}_cvp${{ env._CVP_VERSION }}
+      # build the image
+      - name: Build without pushing
+        uses: docker/build-action@v4
+        if: github.repository_owner != 'arista-netdevops-community'
+        with:
+          push: true
+          build-args: |
+            _AVD_VERSION=${{ env._AVD_VERSION }}
+            _CVP_VERSION=${{ env._CVP_VERSION }}
+            _RELEASE_DATE=${{ env._RELEASE_DATE }}
+          # images: ghcr.io/arista-netdevops-community/avd-all-in-one-container/avd-all-in-one
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64/v8,linux/amd64
       # build and push the image
       - name: Build and push
         uses: docker/build-push-action@v4
+        if: github.repository_owner == 'arista-netdevops-community'
         with:
           push: true
           build-args: |


### PR DESCRIPTION
# Changes
- Bump AVD version to 3.8.4
- Amend github workflow to skip pushing artifacts on forked repos