### PR TITLE
Update k8s-avd-cvp.yml

### DIFF
--- a/k8s-avd-cvp.yml
+++ b/k8s-avd-cvp.yml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: avd
     spec:
-      node: $PRIMARY_HOSTNAME
+      nodeName: $PRIMARY_HOSTNAME
       hostNetwork: false
       securityContext:
         runAsUser: 1000


### PR DESCRIPTION
`syntax` typo , it should be nodeName, else get below error


`
[root@cvp01 kubernetes]# kubectl create -f avd.yaml --dry-run --validate=true
W0612 13:37:36.748298    8126 helpers.go:553] --dry-run is deprecated and can be replaced with --dry-run=client.
error: error validating "avd.yaml": error validating data: ValidationError(Deployment.spec.template.spec): unknown field "node" in io.k8s.api.core.v1.PodSpec; if you choose to ignore these errors, turn validation off with --validate=false
[root@cvp01 kubernetes]#
`